### PR TITLE
Removes API call to `REACT_APP_POKE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Our email system currently makes 6 separate GET requests to the following endpoi
 ```
 REACT_APP_SUBMISSION_DATA
 REACT_APP_AUTHORS
-REACT_APP_POKE
 REACT_APP_TEMPLATES_URL
 REACT_APP_GET_EMAILS_URL
 ```

--- a/api.json
+++ b/api.json
@@ -48480,16 +48480,18 @@
       },
       "1769": {
         "exercises": {
-          "status": "Almost done",
-          "submit_hist": [
-            {
-              "author": 1769,
-              "exid": 1,
-              "status": "Almost done",
-              "submitted": 1538710374995
-            }
-          ],
-          "submitted": 1538710374995
+          "1": {
+            "status": "Almost done",
+            "submit_hist": [
+              {
+                "author": 1769,
+                "exid": 1,
+                "status": "Almost done",
+                "submitted": 1538710374995
+              }
+            ],
+            "submitted": 1538710374995
+          }
         },
         "submissions": [
           {
@@ -53326,16 +53328,18 @@
       },
       "1779": {
         "exercises": {
-          "status": "Not done",
-          "submit_hist": [
-            {
-              "author": 1779,
-              "exid": 1,
-              "status": "Not done",
-              "submitted": 1540978240687
-            }
-          ],
-          "submitted": 1540978240687
+          "1": {
+            "status": "Not done",
+            "submit_hist": [
+              {
+                "author": 1779,
+                "exid": 1,
+                "status": "Not done",
+                "submitted": 1540978240687
+              }
+            ],
+            "submitted": 1540978240687
+          }
         },
         "submissions": [
           {

--- a/src/help-system/CriticStructure.ts
+++ b/src/help-system/CriticStructure.ts
@@ -66,12 +66,11 @@ interface EmailRecord {
 
 export type EmailHistory = Record<authorId, EmailRecord[]>;
 
+export type AuthorsMap = Record<authorId, AuthorSubmissionHistory>;
+
 export interface ApiResponse {
   authors: {
     authors: Record<authorId, Author>;
-  };
-  poke: {
-    authors: Record<authorId, AuthorSubmissionHistory>;
   };
   submissions: Submissions;
   templates: Templates;

--- a/src/help-system/studentRanker.ts
+++ b/src/help-system/studentRanker.ts
@@ -13,6 +13,7 @@ import {
   scoreStudent,
   getStudentMap,
   emailedThisWeek,
+  authorsMap,
 } from "./utils";
 import * as tagReducers from "./tagReducers";
 import * as tagPostProcessors from "./tagPostProcessors";
@@ -34,8 +35,9 @@ const getAuthors = (info: WebContext): Author[] =>
 
 const makeStudents = (context: WebContext): Student[] => {
   const ctx = getCourseContext(context);
+  const authors = authorsMap(context.data);
   const makeStudent = (author: Author): Student => {
-    const history = context.data.poke.authors[author.id];
+    const history = authors[author.id];
     return {
       ...author,
       previousEmail: null,
@@ -43,7 +45,7 @@ const makeStudents = (context: WebContext): Student[] => {
     };
   };
   const filterIssues = (student: Student): Student => {
-    const history = context.data.poke.authors[student.id];
+    const history = authors[student.id];
     const { issues } = student;
     return { ...student, issues: filterTags({ issues, history, ctx }) };
   };

--- a/src/help-system/utils.test.ts
+++ b/src/help-system/utils.test.ts
@@ -1,0 +1,15 @@
+import { authorsMap } from "./utils";
+import apiJson from "../../api.json";
+
+describe("Creating an authors map", () => {
+  test("Works on the example data", () => {
+    expect(apiJson.REACT_APP_POKE.authors).toEqual(
+      authorsMap({
+        authors: apiJson.REACT_APP_AUTHORS,
+        submissions: apiJson.REACT_APP_SUBMISSION_DATA as any,
+        templates: {},
+        emailHistory: [],
+      })
+    );
+  });
+});

--- a/src/help-system/utils.ts
+++ b/src/help-system/utils.ts
@@ -34,6 +34,7 @@ import {
   submissionId,
   Status,
   Submission,
+  Submissions,
   SubmissionHistory,
   ApiResponse,
   AuthorsMap,
@@ -290,51 +291,66 @@ interface Exercises {
   submit_hist: Array<Submission>;
 }
 
+const addExercise = (acc: AuthorSubmissionHistory, submission: Submission) => ({
+  ...acc.exercises[submission.exid],
+  submit_hist: [...acc.exercises[submission.exid].submit_hist, submission],
+});
+
+const makeExercise = (submission: Submission): Exercises => ({
+  status: "Not done",
+  submitted: 0,
+  submit_hist: [submission],
+});
+
+const hasExercise = (
+  acc: AuthorSubmissionHistory,
+  submission: Submission
+): boolean => acc.exercises[submission.exid] !== undefined;
+
+const makeSubmissionHistory = (
+  authorSubmissions: Submission[]
+): AuthorSubmissionHistory =>
+  authorSubmissions.reduce(
+    (acc, submission) => ({
+      ...acc,
+      exercises: {
+        ...acc.exercises,
+        [submission.exid]: hasExercise(acc, submission)
+          ? addExercise(acc, submission)
+          : makeExercise(submission),
+      },
+    }),
+    {
+      submissions: authorSubmissions,
+      exercises: {} as Record<number, SubmissionHistory>,
+    }
+  );
+
+const sortSubmissionHistory = (hist: AuthorSubmissionHistory): void => {
+  Object.values(hist.exercises).forEach((ex: SubmissionHistory) => {
+    ex.submit_hist.sort((a, b) => (a.submitted < b.submitted ? -1 : 1));
+    const latestSubmission = ex.submit_hist[ex.submit_hist.length - 1];
+    ex.submitted = latestSubmission.submitted;
+    ex.status = latestSubmission.status;
+  });
+};
+
+const getAuthorsSubmissions = (
+  submissions: Submissions,
+  id: string
+): Submission[] =>
+  Object.values(submissions.submissions).filter(
+    (submission) => submission.author === Number.parseInt(id, 10)
+  );
+
 export const authorsMap = ({
   authors,
   submissions,
 }: ApiResponse): AuthorsMap => {
   return Object.keys(authors.authors).reduce((acc: AuthorsMap, authorId) => {
-    const authorSubmissions = Object.values(submissions.submissions).filter(
-      (submission) => submission.author === Number.parseInt(authorId, 10)
-    );
-
-    const history: AuthorSubmissionHistory = authorSubmissions.reduce(
-      (acc: AuthorSubmissionHistory, submission) => {
-        return {
-          ...acc,
-          exercises: {
-            ...acc.exercises,
-            [submission.exid]:
-              acc.exercises[submission.exid] !== undefined
-                ? {
-                    ...acc.exercises[submission.exid],
-                    submit_hist: [
-                      ...acc.exercises[submission.exid].submit_hist,
-                      submission,
-                    ],
-                  }
-                : {
-                    status: "Not done",
-                    submitted: 0,
-                    submit_hist: [submission],
-                  },
-          },
-        };
-      },
-      {
-        submissions: authorSubmissions,
-        exercises: {} as Record<number, SubmissionHistory>,
-      }
-    );
-    Object.values(history.exercises).forEach((ex: SubmissionHistory) => {
-      ex.submit_hist.sort((a, b) => (a.submitted < b.submitted ? -1 : 1));
-      const latestSubmission = ex.submit_hist[ex.submit_hist.length - 1];
-      ex.submitted = latestSubmission.submitted;
-      ex.status = latestSubmission.status;
-    });
-    return { ...acc, [authorId]: history };
+    const authorSubmissions = getAuthorsSubmissions(submissions, authorId);
+    const hist = makeSubmissionHistory(authorSubmissions);
+    sortSubmissionHistory(hist);
+    return { ...acc, [authorId]: hist };
   }, {});
-  // console.log(Object.keys(authors.authors));
-  // throw new Error("UNIMPLEMENTED");
 };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -6,7 +6,6 @@ import "@testing-library/jest-dom";
 import "jest-localstorage-mock";
 process.env.REACT_APP_SUBMISSION_DATA = "/example-submission-data.json";
 process.env.REACT_APP_AUTHORS = "/authors.json";
-process.env.REACT_APP_POKE = "/poke-325-export.json";
 process.env.REACT_APP_POST_EMAILS_URL = "/emails";
 process.env.REACT_APP_TEMPLATES_URL = "/templates";
 process.env.REACT_APP_GET_EMAILS_URL = "/emails";

--- a/src/views/EmailGateway.test.tsx
+++ b/src/views/EmailGateway.test.tsx
@@ -6,7 +6,6 @@ import App from "../App";
 import { queryClient } from "./Providers";
 import submissions from "../../server/example-submission-data.json";
 import authors from "../../server/authors.json";
-import poke from "../../server/poke-325-export.json";
 
 console.error = jest.fn();
 const mock = new AxiosMock(axios);
@@ -20,7 +19,6 @@ describe("Our email fetcher component", () => {
   test("Renders an error message when there's an error", async () => {
     mock.onGet("/example-submission-data.json").networkError();
     mock.onGet("/authors.json").networkError();
-    mock.onGet("/poke-325-export.json").networkError();
     mock.onGet("/templates").networkError();
     mock.onGet("/emails").networkError();
     const { getByTestId } = render(<App />);
@@ -33,7 +31,6 @@ describe("Our email fetcher component", () => {
       .onGet("/example-submission-data.json")
       .reply(200, { submissions: "submissions" });
     mock.onGet("/authors.json").reply(200, { authors: "authors" });
-    mock.onGet("/poke-325-export.json").reply(200, { authors: "authors" });
     mock.onGet("/templates").reply(200, { templates: "templates" });
     mock.onGet("/emails").reply(200, { emailHistory: "emailHistory" });
     const { submissions, authors } = await fetchEmailStatistics();
@@ -47,7 +44,6 @@ describe("Our email fetcher component", () => {
   test("Renders a nothing found message when nothing is found", async () => {
     mock.onGet("/example-submission-data.json").reply(200, { submissions: {} });
     mock.onGet("/authors.json").reply(200, { authors: {} });
-    mock.onGet("/poke-325-export.json").reply(200, { authors: {} });
     mock.onGet("/templates").reply(200, { templates: {} });
     mock.onGet("/emails").reply(200, { emailHistory: "emailHistory" });
     const { getByTestId } = render(<App />);
@@ -58,7 +54,6 @@ describe("Our email fetcher component", () => {
   test("Renders the email message when emails are found", async () => {
     mock.onGet("/example-submission-data.json").reply(200, submissions);
     mock.onGet("/authors.json").reply(200, authors);
-    mock.onGet("/poke-325-export.json").reply(200, poke);
     mock.onGet("/templates").reply(200, { templates: {} });
     mock.onGet("/emails").reply(200, { emailHistory: "emailHistory" });
     const { getByTestId } = render(<App />);

--- a/src/views/EmailGateway.tsx
+++ b/src/views/EmailGateway.tsx
@@ -7,16 +7,15 @@ import EmailsView from "./EmailsView";
 import { ApiResponse } from "../help-system";
 
 export const fetchEmailStatistics = async (): Promise<ApiResponse> => {
-  const [submissions, authors, poke, templates, emailHistory] = (
+  const [submissions, authors, templates, emailHistory] = (
     await Promise.all([
       axios.get(process.env.REACT_APP_SUBMISSION_DATA!),
       axios.get(process.env.REACT_APP_AUTHORS!),
-      axios.get(process.env.REACT_APP_POKE!),
       axios.get(process.env.REACT_APP_TEMPLATES_URL!),
       axios.get(process.env.REACT_APP_GET_EMAILS_URL!),
     ])
   )?.map((el) => el.data);
-  return { submissions, authors, poke, templates, emailHistory };
+  return { submissions, authors, templates, emailHistory };
 };
 
 const EmailsError = () => {


### PR DESCRIPTION
This patch removes a network request by computing the `AuthorSubmissionHistory` objects from existing data instead of fetching it from the server. Setting up the `REACT_APP_POKE` endpoint should no longer be necessary for the code to work.